### PR TITLE
0010 [dc] docs-drift-check

### DIFF
--- a/agents/chats/0010-dc-docs-drift-check/DECISION.md
+++ b/agents/chats/0010-dc-docs-drift-check/DECISION.md
@@ -1,0 +1,22 @@
+# DECISION
+
+**Status:** Approved/Closed
+**Date:** 2025-09-07
+**Decided by:** Architect
+
+## Decision
+Adopt a CI guard that enforces “docs as contracts”: regenerate generated docs, fail on drift under `docs/_generated/**`, then build Sphinx with `-W`.
+
+## Implementation Notes
+- Workflow `.github/workflows/docs.yml` runs on PR to dev/staging/main and push to main.
+- Steps: pip install deps → `python manage.py docs_export --erd --api --schemas` → `git diff --exit-code -- docs/_generated` → `make -C docs -W html`.
+- Uploads the built HTML as an artifact for inspection.
+
+## Outcomes
+- Local: `make docs` runs export + drift check + Sphinx build.
+- CI: PRs fail on drift with a clear message; otherwise Sphinx builds with warnings treated as errors.
+
+## Lessons Learned
+- Locking docs early prevents drift as code evolves.
+- Using Makefile targets keeps local and CI workflows aligned.
+

--- a/agents/chats/0010-dc-docs-drift-check/SUMMARY.md
+++ b/agents/chats/0010-dc-docs-drift-check/SUMMARY.md
@@ -1,0 +1,34 @@
+# SUMMARY
+
+## Scope
+Enforce “docs as contracts” via CI: export generated docs, fail on drift under `docs/_generated/**`, then build Sphinx with `-W`.
+
+## Conversation
+- 001-to-engineer (architect): Spec for docs workflow and Make targets.
+- 002-to-architect (engineer): Confirmed workflow present and green; make docs passes locally; CI fails on drift.
+- 003-to-engineer (architect): Accepted and closed.
+
+## Key Changes
+- Added `.github/workflows/docs.yml` (CI: export → drift check → Sphinx -W).
+- Makefile targets (`docs-export`, `docs-drift-check`, `docs`) available for local parity.
+
+## Technical Details
+### Architecture
+- CI-only guard to keep generated docs and manual docs in lockstep.
+
+### Implementation
+- Python 3.11 setup, pip install requirements, export docs, drift check, Sphinx -W build, HTML artifact upload.
+
+## Validation
+- Local: `make docs` green.
+- CI: Editing a generated file without export causes failure.
+
+## Risks & Mitigations
+- None; isolated to CI.
+
+## Follow-up Items
+- [ ] Optional: Link docs build badge in README.
+
+## PR Links
+- PR: TBD (engineer to open to `dev`).
+

--- a/agents/chats/0010-dc-docs-drift-check/meta.yaml
+++ b/agents/chats/0010-dc-docs-drift-check/meta.yaml
@@ -24,7 +24,7 @@ outputs:
 
 gh:
   sync_mode: "issue-dryrun"
-  title_pattern: "^{id} \[{area}\] {slug}$"
+  title_pattern: '^{id} \[{area}\] {slug}$'
   labels: ["chat","area:dc"]
   issue_body_source: "SUMMARY.md"
 

--- a/agents/chats/0010-dc-docs-drift-check/meta.yaml
+++ b/agents/chats/0010-dc-docs-drift-check/meta.yaml
@@ -8,8 +8,8 @@ branch: feat/dc-docs-drift-check-0010
 created: "2025-09-07T16:30:00Z"
 
 scope:
-  - Add GitHub Action: export generated docs, fail on drift, build Sphinx with -W
-  - Keep CI PR-gated; no secrets
+  - "Add GitHub Action: export generated docs, fail on drift, build Sphinx with -W"
+  - "Keep CI PR-gated; no secrets"
 
 non_goals:
   - No code behavior changes

--- a/agents/chats/0010-dc-docs-drift-check/meta.yaml
+++ b/agents/chats/0010-dc-docs-drift-check/meta.yaml
@@ -1,0 +1,36 @@
+id: "0010"
+area: dc
+slug: docs-drift-check
+title: Enforce docs drift check + Sphinx -W
+owner: architect
+state: closed
+branch: feat/dc-docs-drift-check-0010
+created: "2025-09-07T16:30:00Z"
+
+scope:
+  - Add GitHub Action: export generated docs, fail on drift, build Sphinx with -W
+  - Keep CI PR-gated; no secrets
+
+non_goals:
+  - No code behavior changes
+  - No live deploy hooks
+
+acceptance:
+  - make docs
+  - (in PR) drift causes CI failure on docs/_generated/** difference
+
+outputs:
+  - .github/workflows/docs.yml
+
+gh:
+  sync_mode: "issue-dryrun"
+  title_pattern: "^{id} \[{area}\] {slug}$"
+  labels: ["chat","area:dc"]
+  issue_body_source: "SUMMARY.md"
+
+ci_gates:
+  - meta-schema
+  - pr-title
+
+notes: |
+  Small CI-only change to lock "docs as contracts". Use Makefile target `make docs` locally; CI runs equivalent steps.


### PR DESCRIPTION
## Summary
Chat closure artifacts only - implementation already in dev.

## Chat
0010-dc-docs-drift-check

## Changes
- Add chat closure artifacts (DECISION.md, SUMMARY.md, meta.yaml)
- No code changes - docs drift check workflow and Makefile targets already merged

## Acceptance Criteria Met
- ✅ `make docs` runs successfully  
- ✅ Drift causes CI failure with clear error message
- ✅ Sphinx builds with -W flag enforcing no warnings

## Type
Documentation only - chat closure