### PR TITLE
ci: pin processor images

### DIFF
--- a/code/apps/core/registry/processors/llm_litellm.yaml
+++ b/code/apps/core/registry/processors/llm_litellm.yaml
@@ -1,6 +1,6 @@
 ref: llm/litellm@1
 image:
-  oci: ghcr.io/veyorokon/theory-api/llm-litellm@sha256:pending
+  oci: ghcr.io/veyorokon/theory-api/llm_litellm@sha256:a9ac7c3f2cc32a79753d81341388594efd665cc1f0f1b01b73a17e1055989b06
 build:
   context: .
   dockerfile: apps/core/processors/llm_litellm/Dockerfile

--- a/code/apps/core/registry/processors/replicate_generic.yaml
+++ b/code/apps/core/registry/processors/replicate_generic.yaml
@@ -4,16 +4,15 @@ runtime:
   memory: 2Gi
   gpu: none
 image:
-  # Replace with actual digest once Build & Pin runs
-  oci: ghcr.io/veyorokon/theory-api/replicate-generic@sha256:pending
+  oci: ghcr.io/veyorokon/theory-api/replicate_generic@sha256:3ef647bcc9c5f3568fb734d2655172e198fa568ecffa06ce2c60851c39de90e0
 build:
   context: .
   dockerfile: apps/core/processors/replicate_generic/Dockerfile
 secrets:
   required:
-    - REPLICATE_API_TOKEN
+  - REPLICATE_API_TOKEN
   optional: []
 policy:
-  network: egress   # smoke will override with mock; no real network in CI
+  network: egress
   max_file_mb: 100
   request_timeout_s: 120


### PR DESCRIPTION
This PR pins processor images to the latest built digests.

• Workflow: Build & Pin  
• Run: 17874512210
• Auto-generated by GitHub Actions

Updated registry files:
- llm_litellm.yaml
- replicate_generic.yaml