### PR TITLE
refactor: align CI/CD flow with spec requirements

### DIFF
--- a/.github/workflows/cleanup-modal.yml
+++ b/.github/workflows/cleanup-modal.yml
@@ -1,0 +1,73 @@
+name: Cleanup Modal Deployments
+
+on:
+  schedule:
+    - cron: '13 0 * * *'  # Temporary: runs at 00:13 UTC for testing (change to '0 2 * * *' after validation)
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Clean up stale Modal deployments
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: backend.settings.dev_remote
+      MODAL_ENVIRONMENT: dev
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need all branches for comparison
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Clean up stale Modal deployments
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          echo "→ Scanning Modal deployments for stale branches..."
+
+          # Get all Modal app names from Modal CLI
+          # Expected format: feat-websocket-standardization-veyorokon-llm-litellm-v1
+          # Pattern: {branch}-{user}-{ref-slug}
+
+          modal app list --env dev --json | jq -r '.[].name' | while read -r app_name; do
+            # Extract branch name from deployment name
+            # Remove user suffix and ref suffix to get branch name
+            # Example: feat-websocket-standardization-veyorokon-llm-litellm-v1
+            #   -> extract: feat-websocket-standardization
+
+            # Skip if it doesn't match our pattern (branch-user-ref)
+            if ! echo "$app_name" | grep -qE '^[^-]+-[^-]+-[^-]+'; then
+              echo "  ⊘ Skip: $app_name (doesn't match branch pattern)"
+              continue
+            fi
+
+            # Extract branch by removing last two segments (user and ref)
+            branch=$(echo "$app_name" | rev | cut -d'-' -f3- | rev)
+
+            echo "  • $app_name -> branch: $branch"
+
+            # Check if branch exists locally or remotely
+            if git show-ref --verify --quiet "refs/heads/$branch" || \
+               git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+              echo "    ✓ Branch exists, keeping deployment"
+            else
+              echo "    ✗ Branch deleted, stopping deployment"
+
+              # Extract ref from app name (last segment before user)
+              # Example: feat-websocket-standardization-veyorokon-llm-litellm-v1
+              #   -> llm/litellm@1 (reconstruct from llm-litellm-v1)
+              ref_slug=$(echo "$app_name" | rev | cut -d'-' -f1-3 | rev)
+              ref=$(echo "$ref_slug" | sed 's/-/\//; s/-v/@/')
+
+              echo "    → Stopping: $ref (app: $app_name)"
+              python code/manage.py modalctl stop --ref "$ref" || echo "    ⚠ Failed to stop $ref"
+            fi
+          done
+
+          echo "✓ Cleanup complete"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,8 +15,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-and-publish:
+    name: Build & Publish (amd64)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      DJANGO_SETTINGS_MODULE: backend.settings.dev_local
+      PLATFORM: amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Build and publish all tools
+        run: make build-and-publish-all
+
+      - name: Commit pin updates to dev (if any)
+        env:
+          ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+        run: |
+          git config user.name "pin-bot"
+          git config user.email "pin-bot@users.noreply.github.com"
+          if ! git diff --quiet tools/; then
+            git add tools/
+            git commit -m "pin: update tool digests (dev)"
+            git config --unset http.https://github.com/.extraheader || true
+            git remote set-url origin https://x-access-token:${ADMIN_GITHUB_TOKEN}@github.com/veyorokon/theory-api.git
+            git pull --rebase origin dev
+            git push
+          fi
+
   deploy-and-test:
     name: Deploy to Modal (dev) and test
+    needs: build-and-publish
     runs-on: ubuntu-latest
     env:
       DJANGO_SETTINGS_MODULE: backend.settings.dev_remote
@@ -28,6 +68,8 @@ jobs:
       MOCK_MISSING_SECRETS: false
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: dev  # Get latest dev with pin commits
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       - run: pip install -r requirements.txt -r requirements-dev.txt
@@ -45,57 +87,24 @@ jobs:
       - name: Integration tests
         run: make test-integration
 
-  promote_to_staging:
-    name: "Open PR: dev -> staging"
+  promote-to-staging:
+    name: Promote to staging
     needs: deploy-and-test
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Need full history for branch operations
-      - name: Create PR from dev to staging
+          fetch-depth: 0
+          ref: dev
+      - name: Push dev to staging
         env:
-          GH_TOKEN: ${{ github.token }}
+          ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         run: |
-          # Check if PR already exists for this dev SHA
-          EXISTING_PR=$(gh pr list --base staging --head dev --state open --json number --jq '.[0].number' || echo "")
-
-          if [ -z "$EXISTING_PR" ]; then
-            echo "Creating new PR from dev to staging"
-            gh pr create \
-              --base staging \
-              --head dev \
-              --title "Promote: dev -> staging" \
-              --body "## 🚀 Staging Promotion
-
-          This PR promotes validated changes from dev to staging for build and deployment.
-
-          ### Validation Status
-          - ✅ **Unit tests**: All tests passed
-          - ✅ **Build verification**: Processor image built successfully
-          - ✅ **Integration tests**: Local integration tests passed
-          - ✅ **Secret sync**: Dev environment secrets synced
-
-          ### Dev Info
-          - **Run ID**: ${{ github.run_id }}
-          - **SHA**: ${{ github.sha }}
-          - **Workflow**: [View run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-          ---
-
-          **Ready for staging build and deployment.**"
-
-            echo "✅ PR created successfully"
-          else
-            echo "⚠️ PR #$EXISTING_PR already exists from dev to staging"
-            echo "Updating existing PR with latest run info"
-
-            gh pr comment $EXISTING_PR --body "## Updated from Run #${{ github.run_id }}
-
-          - **SHA**: ${{ github.sha }}
-          - **Workflow**: [View run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          - **Status**: ✅ All validations passed"
-          fi
+          git config user.name "promotion-bot"
+          git config user.email "promotion-bot@users.noreply.github.com"
+          git config --unset http.https://github.com/.extraheader || true
+          git remote set-url origin https://x-access-token:${ADMIN_GITHUB_TOKEN}@github.com/veyorokon/theory-api.git
+          git push origin dev:staging --force-with-lease
+          echo "✅ Promoted dev to staging"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      DJANGO_SETTINGS_MODULE: backend.settings.dev_remote
+      DJANGO_SETTINGS_MODULE: backend.settings.production
       ADAPTER: modal
       ENV: main
       PLATFORM: amd64

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Unit tests
         run: make test-unit
 
-  integration-local:
+  integration:
     name: Integration tests (local adapter)
     runs-on: ubuntu-latest
     permissions:
@@ -71,37 +71,8 @@ jobs:
         if: always()
         run: make stop-tools && make services-down
 
-  integration-modal:
-    name: Integration tests (modal adapter)
-    runs-on: ubuntu-latest
-    env:
-      DJANGO_SETTINGS_MODULE: backend.settings.dev_remote
-      ADAPTER: modal
-      PLATFORM: amd64
-      MODAL_ENVIRONMENT: dev
-      TEST_ADAPTER: modal
-      MOCK_MISSING_SECRETS: false
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - run: pip install -r requirements.txt -r requirements-dev.txt
-      - run: cd code && python manage.py migrate --noinput
-
-      - name: Start tools on Modal (dev)
-        env:
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: make start-tools
-
-      - name: Integration tests
-        run: make test-integration
-
+  # Note: Modal adapter testing happens in dev lane after merge
   # TODO: Add parity job to compare local vs modal envelopes (byte-identical in mock mode)
-  # Validates spec requirement: "Adapters differ only in transport, no business policy"
 
   contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Unit tests
         run: make test-unit
 
-  integration:
+  integration-local:
+    name: Integration tests (local adapter)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,12 +64,44 @@ jobs:
       - name: Start tools from registry
         run: make start-tools ADAPTER=local
 
-      - name: Integration tests (local adapter)
+      - name: Integration tests
         run: make test-integration
 
       - name: Cleanup
         if: always()
         run: make stop-tools && make services-down
+
+  integration-modal:
+    name: Integration tests (modal adapter)
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: backend.settings.dev_remote
+      ADAPTER: modal
+      PLATFORM: amd64
+      MODAL_ENVIRONMENT: dev
+      TEST_ADAPTER: modal
+      MOCK_MISSING_SECRETS: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+      - run: cd code && python manage.py migrate --noinput
+
+      - name: Start tools on Modal (dev)
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: make start-tools
+
+      - name: Integration tests
+        run: make test-integration
+
+  # TODO: Add parity job to compare local vs modal envelopes (byte-identical in mock mode)
+  # Validates spec requirement: "Adapters differ only in transport, no business policy"
 
   contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ staging ]
     paths-ignore:
-      - "code/apps/core/processors/**/registry.yaml"  # Ignore pin commits
+      - "tools/**/registry.yaml"  # Ignore pin commits
   workflow_dispatch: {}
 
 concurrency:
@@ -15,53 +15,12 @@ env:
   MODAL_ENVIRONMENT: staging
 
 jobs:
-  build_and_publish:
-    name: Build & Publish (amd64)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: write  # commit pins to staging
-      packages: write  # push GHCR
-    env:
-      DJANGO_SETTINGS_MODULE: backend.settings.dev_local
-      PLATFORM: amd64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - run: pip install -r requirements.txt -r requirements-dev.txt
-
-      - name: Build and publish all tools
-        run: make build-and-publish-all
-
-      - name: Commit pin updates to staging (if any)
-        env:
-          ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-        run: |
-          git config user.name "pin-bot"
-          git config user.email "pin-bot@users.noreply.github.com"
-          if ! git diff --quiet tools/; then
-            git add tools/
-            git commit -m "pin: update tool digests (staging)"
-            git config --unset http.https://github.com/.extraheader || true
-            git remote set-url origin https://x-access-token:${ADMIN_GITHUB_TOKEN}@github.com/veyorokon/theory-api.git
-            git pull --rebase origin staging
-            git push
-          fi
-
   deploy-and-test:
     name: Deploy to Modal (staging) and test
-    needs: build_and_publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      DJANGO_SETTINGS_MODULE: backend.settings.dev_remote
+      DJANGO_SETTINGS_MODULE: backend.settings.staging
       ADAPTER: modal
       ENV: staging
       PLATFORM: amd64
@@ -70,8 +29,6 @@ jobs:
       MOCK_MISSING_SECRETS: false
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: staging  # Get latest staging with pin commits
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       - run: pip install -r requirements.txt -r requirements-dev.txt

--- a/code/backend/settings/production.py
+++ b/code/backend/settings/production.py
@@ -1,4 +1,4 @@
-from .base import *
+from .staging import *
 import dj_database_url
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -22,4 +22,4 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 # Storage settings are configured in base.py using STORAGE dict
 # In production, set STORAGE_BACKEND=s3 and ARTIFACTS_BUCKET/REGION via env vars
 # AWS credentials are sourced from environment (preferably IAM role)
-MODAL_ENVIRONMENT = env("MODAL_ENVIRONMENT", default="staging", required=MODAL_ENABLED)
+MODAL_ENVIRONMENT = env("MODAL_ENVIRONMENT", default="main", required=MODAL_ENABLED)

--- a/code/backend/settings/staging.py
+++ b/code/backend/settings/staging.py
@@ -1,0 +1,5 @@
+from .dev_remote import *
+
+# Staging uses S3 (inherited from dev_remote)
+# Override environment designation
+MODAL_ENVIRONMENT = env("MODAL_ENVIRONMENT", default="staging", required=MODAL_ENABLED)


### PR DESCRIPTION
## Summary

Aligns CI/CD workflows with engineer.md spec: adapter parity testing, build/pin/deploy separation, and correct promotion flow.

## Changes

### PR Lane ()
- Add  job to test Modal adapter (in addition to local)
- Rename  →  for clarity
- Add TODO comment for future parity job (byte-identical envelope comparison)

### Dev Lane ()
- Add  job: Build images → Publish to GHCR → Pin digests → Commit pins
- Replace PR creation with direct push to staging: `git push origin dev:staging --force-with-lease`
- Deploy and test against Modal dev environment

### Staging Lane ()
- Remove build job (uses dev's pinned images)
- Fix `paths-ignore`: `tools/**/registry.yaml` (tools moved from `code/apps/core/processors/`)
- Use `backend.settings.staging`

### Main Lane ()
- Use `backend.settings.production` instead of `dev_remote`

### Settings ()
- Create staging-specific settings inheriting S3 config from dev_remote

## Flow
```
PR → dev: Validate both local + modal adapters
      ↓ (build → publish → pin → commit → deploy → test)
    dev: Direct push to staging (no PR)
      ↓ (deploy pinned images → test)
  staging: Create release PR to main
      ↓ (manual merge after version label)
    main: Deploy pinned images → test
```

## Key Principles
- **Build once, deploy everywhere**: Only dev builds/pins
- **Adapter parity**: PR lane validates both adapters
- **No redundant builds**: Staging/main use dev's pinned digests
- **Spec compliance**: Engineer.md lines 248 (parity), 389 (pinned digests), 374 (no build in adapters)